### PR TITLE
Fix build Errors for devkitA64 11.1

### DIFF
--- a/source/save.cpp
+++ b/source/save.cpp
@@ -1,5 +1,7 @@
 #include "save.hpp"
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "account.hpp"


### PR DESCRIPTION
as suggested by wintermute, makes it build properly.